### PR TITLE
Allow "number" type for textual inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     magrittr,
     utils
 Suggests:
-    testthat,
+    testthat (>= 2.1.0),
     knitr,
     rmarkdown
 VignetteBuilder: knitr

--- a/R/textual.R
+++ b/R/textual.R
@@ -4,6 +4,7 @@ possible_types <- c(
   "datetime-local",
   "email",
   "month",
+  "number",
   "password",
   "search",
   "tel",

--- a/R/textual.R
+++ b/R/textual.R
@@ -71,6 +71,19 @@ param_type <- function() {
 #'
 #' textInput(id = "text")
 #'
+#' ### Default number input
+#'
+#' numberInput(id = "num1")
+#'
+#' ### Specify `min`, `max`, and `step`
+#'
+#' numberInput(
+#'   id = "num2",
+#'   min = 1,
+#'   max = 10,
+#'   step = 2
+#' )
+#'
 textInput <- function(id, value = NULL, placeholder = NULL, ...,
                       type = "text") {
   assert_id()

--- a/R/textual.R
+++ b/R/textual.R
@@ -39,7 +39,8 @@ param_type <- function() {
 #' input.
 #'
 #' `numberInput()` is a simple wrapper around `textInput()` with `type` set to
-#' `"number"`. Because of this use `updateTextInput()` to update a number input.
+#' `"number"` and explicit arguments for specifying a min value, max value, and
+#' the step amount. Use `updateTextInput()` to update a number input.
 #'
 #' @inheritParams checkboxInput
 #'
@@ -52,6 +53,15 @@ param_type <- function() {
 #'   input, defaults to `NULL`, in which case there is no placeholder text.
 #'
 #' @eval param_type()
+#'
+#' @param min A number specifying the minimum allowed value of the number input,
+#'   defaults to `NULL`.
+#'
+#' @param max A number specifying the maximum allowed value of the number input,
+#'   defaults to `NULL`.
+#'
+#' @param step A number specifying the increment step of the number input,
+#'   defaults to 1.
 #'
 #' @family inputs
 #' @export
@@ -86,14 +96,23 @@ textInput <- function(id, value = NULL, placeholder = NULL, ...,
 
 #' @rdname textInput
 #' @export
-numberInput <- function(id, value = NULL, placeholder = NULL, ...) {
+numberInput <- function(id, value = NULL, placeholder = NULL, ..., min = NULL,
+                        max = NULL, step = 1) {
   assert_id()
 
-  textInput(
+  component <- textInput(
     id = id, value = value, placeholder = placeholder, ...,
     type = "number"
   )
+
+  component$children[[1]] <- tag_attributes_add(
+    component$children[[1]],
+    drop_nulls(list(min = min, max = max, step = step))
+  )
+
+  component
 }
+
 
 #' @rdname textInput
 #' @export

--- a/man/textInput.Rd
+++ b/man/textInput.Rd
@@ -10,7 +10,8 @@
 \usage{
 textInput(id, value = NULL, placeholder = NULL, ..., type = "text")
 
-numberInput(id, value = NULL, placeholder = NULL, ...)
+numberInput(id, value = NULL, placeholder = NULL, ..., min = NULL,
+  max = NULL, step = 1)
 
 updateTextInput(id, value = NULL, enable = NULL, disable = NULL,
   valid = NULL, invalid = NULL, session = getDefaultReactiveDomain())
@@ -34,9 +35,18 @@ input, defaults to \code{NULL}, in which case there is no placeholder text.}
 parent element or tag elements passed as child elements to the parent
 element.}
 
-\item{type}{One of "\code{color}", "\code{date}", "\code{datetime-local}", "\code{email}", "\code{month}", "\code{password}", "\code{search}", "\code{tel}", "\code{text}", "\code{time}", "\code{url}" or "\code{week}" specifying the type of text input, defaults to \code{"text"}.
+\item{type}{One of "\code{color}", "\code{date}", "\code{datetime-local}", "\code{email}", "\code{month}", "\code{number}", "\code{password}", "\code{search}", "\code{tel}", "\code{text}", "\code{time}", "\code{url}" or "\code{week}" specifying the type of text input, defaults to \code{"text"}.
 
 For details on a particular type please see \url{https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input}.}
+
+\item{min}{A number specifying the minimum allowed value of the number input,
+defaults to \code{NULL}.}
+
+\item{max}{A number specifying the maximum allowed value of the number input,
+defaults to \code{NULL}.}
+
+\item{step}{A number specifying the increment step of the number input,
+defaults to 1.}
 
 \item{enable}{One of \code{values} specifying particular choices to enable or
 \code{TRUE} specifying the entire input is enabled, defaults to \code{NULL}.}
@@ -110,7 +120,8 @@ input allows you to include static prefixes or buttons with a standard text
 input.
 
 \code{numberInput()} is a simple wrapper around \code{textInput()} with \code{type} set to
-\code{"number"}. Because of this use \code{updateTextInput()} to update a number input.
+\code{"number"} and explicit arguments for specifying a min value, max value, and
+the step amount. Use \code{updateTextInput()} to update a number input.
 }
 \examples{
 

--- a/man/textInput.Rd
+++ b/man/textInput.Rd
@@ -129,6 +129,19 @@ the step amount. Use \code{updateTextInput()} to update a number input.
 
 textInput(id = "text")
 
+### Default number input
+
+numberInput(id = "num1")
+
+### Specify `min`, `max`, and `step`
+
+numberInput(
+  id = "num2",
+  min = 1,
+  max = 10,
+  step = 2
+)
+
 }
 \seealso{
 Other inputs: \code{\link{buttonGroupInput}},

--- a/tests/testthat/test-text-input.R
+++ b/tests/testthat/test-text-input.R
@@ -1,0 +1,11 @@
+context("Text and number input")
+
+test_that("id argument", {
+  expect_silent(textInput("id"))
+  expect_silent(textInput(NULL))
+  expect_silent(numberInput("id"))
+  expect_silent(numberInput(NULL))
+
+  expect_error(textInput(NA))
+  expect_error(numberInput(NA))
+})

--- a/tests/testthat/test-text-input.R
+++ b/tests/testthat/test-text-input.R
@@ -9,3 +9,12 @@ test_that("id argument", {
   expect_error(textInput(NA))
   expect_error(numberInput(NA))
 })
+
+test_that("min, max, step added to <input> child element", {
+  element <- numberInput("ID", min = 1, max = 10, step = 2)
+
+  expect_equal(element$children[[1]]$attribs$min, 1)
+  expect_equal(element$children[[1]]$attribs$max, 10)
+  expect_equal(element$children[[1]]$attribs$step, 2)
+  expect_match(as.character(element), 'min="1" max="10" step="2"')
+})


### PR DESCRIPTION
* `"number"` is now an allowed type, so `numberInput()` will no longer always error
