### PR TITLE
Update internal version of shiny.js dependency to match the name that shiny actually uses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2
 Depends:
     R (>= 3.2),
-    shiny (>= 1.4.0)
+    shiny (>= 1.6.0)
 Imports:
     htmltools (>= 0.4.0),
     lifecycle,

--- a/R/utils-dependencies.R
+++ b/R/utils-dependencies.R
@@ -110,7 +110,7 @@ dep_yonder <- function() {
       script = "js/bs-custom-file-input.min.js"
     ),
     htmlDependency(
-      name = "shiny",
+      name = "shiny-javascript",
       version = "3.3.3",
       src = c(
         file = system.file("www/shared/", package = "shiny"),


### PR DESCRIPTION
Closes #193

shiny 1.6.0 started separating its JS and CSS dependencies, so ever since that change, shiny's JS was actually executed twice (once before and after yonder) https://github.com/rstudio/shiny/blob/938916/R/shinyui.R#L99